### PR TITLE
MIME type .GX

### DIFF
--- a/plugins/GXWriter/GXWriter.py
+++ b/plugins/GXWriter/GXWriter.py
@@ -41,7 +41,7 @@ class GXWriter(MeshWriter):
         self._snapshot = None
         MimeTypeDatabase.addMimeType(
             MimeType(
-                name = "application/xgcode",
+                name = "application/gx",
                 comment = "GX (xgcode)",
                 suffixes = ["gx"],
             )

--- a/plugins/GXWriter/__init__.py
+++ b/plugins/GXWriter/__init__.py
@@ -24,10 +24,10 @@ def getMetaData():
         "mesh_writer": {
             "output": [
                 {
-                    "mime_type": "application/xgcode",
+                    "mime_type": "application/gx",
                     "mode": MeshWriter.OutputMode.BinaryMode,
                     "extension": "gx",
-                    "description": i18n_catalog.i18nc("@item:inlistbox", "GX (xgcode)")
+                    "description": i18n_catalog.i18nc("@item:inlistbox", "GX (gx)")
                 }
             ]
         }

--- a/plugins/GXWriter/plugin.json
+++ b/plugins/GXWriter/plugin.json
@@ -4,5 +4,6 @@
     "version": "1.0.0",
     "description": "Add tools to help FlashForge Finder users to use Cura as slicer.",
     "api": "7.1.0",
+    "supported_sdk_versions": ["5.0.0", "6.0.0", "7.0.0"],
     "i18n-catalog": "cura"
 }


### PR DESCRIPTION
Changed from x-gcode to .gx
added sdk versions, which supports SDK 7.0 and 6.0 ( works now with Cura 4.0)