### PR TITLE
Fixed paths in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ build/GXWriter-$(VERSION).curapackage: plugins/GXWriter/* LICENSE icon.png
 	mkdir -p build/GXWriter/files/plugins
 	cp LICENSE icon.png build/GXWriter
 	cp -r plugins/GXWriter/ build/GXWriter/files/plugins/
-	mv build/GXWriter/files/plugins/GXWriter/package.json build/GXWriter/
-	sed -i -e 's/"version":.*/"version": "$(VERSION)",/g' build/GXWriter/files/plugins/GXWriter/plugin.json
+	mv build/GXWriter/files/plugins/package.json build/GXWriter/
+	sed -i -e 's/"version":.*/"version": "$(VERSION)",/g' build/GXWriter/files/plugins/plugin.json
 	sed -i -e 's/"package_version":.*/"package_version": "$(VERSION)",/g' build/GXWriter/package.json
 	cd build/GXWriter && \
 		zip ../GXWriter-$(VERSION).curapackage -q \
@@ -38,8 +38,8 @@ build/FlashforgeFinderIntegration-$(VERSION).curapackage: plugins/FlashforgeFind
 	mkdir -p build/FlashforgeFinderIntegration/files/plugins
 	cp LICENSE icon.png build/FlashforgeFinderIntegration
 	cp -r plugins/FlashforgeFinderIntegration/ build/FlashforgeFinderIntegration/files/plugins/
-	mv build/FlashforgeFinderIntegration/files/plugins/FlashforgeFinderIntegration/package.json build/FlashforgeFinderIntegration/
-	sed -i -e 's/"version":.*/"version": "$(VERSION)",/g' build/FlashforgeFinderIntegration/files/plugins/FlashforgeFinderIntegration/plugin.json
+	mv build/FlashforgeFinderIntegration/files/plugins/package.json build/FlashforgeFinderIntegration/
+	sed -i -e 's/"version":.*/"version": "$(VERSION)",/g' build/FlashforgeFinderIntegration/files/plugins/plugin.json
 	sed -i -e 's/"package_version":.*/"package_version": "$(VERSION)",/g' build/FlashforgeFinderIntegration/package.json
 	cd build/FlashforgeFinderIntegration && \
 		zip ../FlashforgeFinderIntegration-$(VERSION).curapackage -q \
@@ -52,7 +52,7 @@ build/FlashforgeFinderIntegration-$(VERSION).curapackage: plugins/FlashforgeFind
 		-x "*testdata*" \
 		-x "*__pycache__*" \
 		-x "*pyc" \
-		-r FlashforgeFinderIntegration
+		-r .
 
 plugins/FlashforgeFinderIntegration/printer/defs/finder.def.json:
 	git submodule init


### PR DESCRIPTION
Altering the paths like this makes the Makefile complete without errors.
The plugin was loaded properly after the build process.