### PR TITLE
Drop support for Cura 4.5 and earlier.

### DIFF
--- a/plugins/FlashforgeFinderIntegration/package.json
+++ b/plugins/FlashforgeFinderIntegration/package.json
@@ -10,7 +10,7 @@
     "package_id": "FlashforgeFinderIntegration",
     "package_type": "plugin",
     "package_version": "1.0.0",
-    "sdk_version": "7.6.0",
+    "sdk_version": "7.2.0",
     "supported_sdk_versions": ["7.0.0"],
     "tags": [
         "Flashforge",

--- a/plugins/FlashforgeFinderIntegration/package.json
+++ b/plugins/FlashforgeFinderIntegration/package.json
@@ -11,7 +11,7 @@
     "package_type": "plugin",
     "package_version": "1.0.0",
     "sdk_version": "7.2.0",
-    "supported_sdk_versions": ["7.0.0"],
+    "supported_sdk_versions": ["7.2.0"],
     "tags": [
         "Flashforge",
 	"Finder"

--- a/plugins/FlashforgeFinderIntegration/package.json
+++ b/plugins/FlashforgeFinderIntegration/package.json
@@ -10,8 +10,8 @@
     "package_id": "FlashforgeFinderIntegration",
     "package_type": "plugin",
     "package_version": "1.0.0",
-    "sdk_version": "7.1.0",
-    "supported_sdk_versions": ["5.0.0", "6.0.0", "7.0.0"],
+    "sdk_version": "7.6.0",
+    "supported_sdk_versions": ["7.0.0"],
     "tags": [
         "Flashforge",
 	"Finder"

--- a/plugins/FlashforgeFinderIntegration/plugin.json
+++ b/plugins/FlashforgeFinderIntegration/plugin.json
@@ -4,6 +4,6 @@
     "version": "1.0.0",
     "description": "Flashforge Finder integration utilities to enable setting up and using the printer. This plugin uses the configuration files from https://github.com/eskeyaar/Flashforge-Finder-",
     "api": 5,
-    "supported_sdk_versions": ["6.0.0", "6.1.0", "6.2.0", "6.3.0", "7.0.0", "7.1.0", "7.2.0"],
+    "supported_sdk_versions": ["7.2.0"],
     "i18n-catalog": "cura"
 }


### PR DESCRIPTION
Since there is more work to do in order to support correctly
the print profiles, and they add value to the integration
implemented in order to better work with the Finder, I'm
dropping support now until I can better test and detect
older versions of Cura.

Later versions can upgrade the profiles based on the settings
versions and as such should not cause any issues.