### PR TITLE
Support for Cura 5.1.0 (SDK 8.1.0)

### DIFF
--- a/plugins/FlashforgeFinderIntegration/package.json
+++ b/plugins/FlashforgeFinderIntegration/package.json
@@ -10,11 +10,20 @@
     "package_id": "FlashforgeFinderIntegration",
     "package_type": "plugin",
     "package_version": "1.0.0",
-    "sdk_version": "7.2.0",
-    "supported_sdk_versions": ["7.2.0"],
+    "sdk_version": "8.1.0",
+    "supported_sdk_versions": [
+        "7.2.0",
+        "7.3.0",
+        "7.4.0",
+        "7.5.0",
+        "7.8.0",
+        "7.9.0",
+        "8.0.0",
+        "8.1.0"
+    ],
     "tags": [
         "Flashforge",
-	"Finder"
+	    "Finder"
     ],
     "website": "https://github.com/ronoaldo/FlashforgeFinderIntegration"
 }

--- a/plugins/FlashforgeFinderIntegration/plugin.json
+++ b/plugins/FlashforgeFinderIntegration/plugin.json
@@ -4,6 +4,15 @@
     "version": "1.0.0",
     "description": "Flashforge Finder integration utilities to enable setting up and using the printer. This plugin uses the configuration files from https://github.com/eskeyaar/Flashforge-Finder-",
     "api": 5,
-    "supported_sdk_versions": ["7.2.0"],
+    "supported_sdk_versions": [
+        "7.2.0",
+        "7.3.0",
+        "7.4.0",
+        "7.5.0",
+        "7.8.0",
+        "7.9.0",
+        "8.0.0",
+        "8.1.0"
+    ],
     "i18n-catalog": "cura"
 }

--- a/plugins/GXWriter/package.json
+++ b/plugins/GXWriter/package.json
@@ -10,13 +10,19 @@
     "package_id": "GXWriter",
     "package_type": "plugin",
     "package_version": "1.0.0",
-    "sdk_version": "7.1.0",
-    "supported_sdk_versions": ["5.0.0", "6.0.0", "7.0.0"],
+    "sdk_version": "8.1.0",
+    "supported_sdk_versions": [
+        "5.0.0",
+        "6.0.0",
+        "7.0.0",
+        "8.0.0",
+        "8.1.0"
+    ],
     "tags": [
         "flashforge",
-	"finder",
-	"monoprice",
-	"xgcode"
+	    "finder",
+	    "monoprice",
+	    "xgcode"
     ],
     "website": "https://github.com/ronoaldo/FlashforgeFinderIntegration"
 }

--- a/plugins/GXWriter/plugin.json
+++ b/plugins/GXWriter/plugin.json
@@ -4,6 +4,21 @@
     "version": "1.0.0",
     "description": "GXWriter writes the required header metadata to printers that interpret GX files, such as Flashforge Finder and Monoprice.",
     "api": 5,
-    "supported_sdk_versions": ["6.0.0", "6.1.0", "6.2.0", "6.3.0", "7.0.0", "7.1.0", "7.2.0"],
+    "supported_sdk_versions": [
+        "6.0.0",
+        "6.1.0",
+        "6.2.0",
+        "6.3.0",
+        "7.0.0",
+        "7.1.0",
+        "7.2.0",
+        "7.3.0",
+        "7.4.0",
+        "7.5.0",
+        "7.8.0",
+        "7.9.0",
+        "8.0.0",
+        "8.1.0"
+    ],
     "i18n-catalog": "cura"
 }


### PR DESCRIPTION
Added support for Cura 5.1.0 (SDK 8.1.0) by changing the supported sdk fields and updating the code from qt5 to qt6