### PR TITLE
Added mime_type to write() to fix an error

### DIFF
--- a/plugins/GXWriter/GXWriter.py
+++ b/plugins/GXWriter/GXWriter.py
@@ -54,7 +54,7 @@ class GXWriter(MeshWriter):
         )
 
     @call_on_qt_thread 
-    def write(self, stream, nodes: List[SceneNode], mode = MeshWriter.OutputMode.BinaryMode) -> bool:
+    def write(self, stream, nodes: List[SceneNode], mode = MeshWriter.OutputMode.BinaryMode, mime_type=None) -> bool:
         Logger.log("i", "Starting GXWriter.")
         if mode != MeshWriter.OutputMode.BinaryMode:
             Logger.log("e", "GXWriter does not support non-text mode.")


### PR DESCRIPTION
Added mime_type to the write() function as @ronoaldo mentioned in issue #31 

I have tested this on my system, and now it doesn't crash when i save a .gx file.